### PR TITLE
Blog Header is now visible.

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -28,7 +28,7 @@
         }
         .blog-header {
             background: linear-gradient(to right, #ff7e5f, #feb47b);
-            padding: 20px;
+            padding: 55px;
             text-align: center;
             color: var(--primary-color);
         }


### PR DESCRIPTION
As you can clearly see in the 1st image that the Header part's text is not visible. 

![1](https://github.com/user-attachments/assets/a4b6c159-b0e6-4462-9330-3539dda0ffb2)


In the second image I've made some changes and now the header text is visible. 

![2](https://github.com/user-attachments/assets/edae115b-8e99-4a6b-8f72-96e7b4ba8ff6)
 
 As I've fix this issue, please add-in these tags: gssoc-ext, hactoberfest-accepted and level.
 