### PR TITLE
Updated Light/Dark Mode BUG

### DIFF
--- a/components/Navbar/Navbar.html
+++ b/components/Navbar/Navbar.html
@@ -35,7 +35,7 @@
                     </li>
                 </ul>
             </div>
-            <img src="/images/dark.png" id="icon" alt="Dark mode toggle" />
+            <button style="background-color:gray; height: 50px; width: 70px;border-radius: 20px;"><img src="/images/dark.png" id="icon" alt="Dark mode toggle" /></button>
         </nav>
     </header>
     <script src="/components/Navbar/Navbar.js"></script>


### PR DESCRIPTION


## Issues Identification #971 
BUG REPORT

## Description
When the page is in Dark mode, the theme switching button disappears due to wrong CSS. Now it it been improved

### Summary
Now user find it easier to switch theme. Earlier user finds difficulty in switching it to Light mode because Button goes Disappear

## Types of Changes
Enhanced CSS


- [x] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (Documentation content changed)
- [ ] 
## Checklist

_Please check the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes do not break the current system and pass all existing test cases
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots
Earlier:
![image](https://github.com/user-attachments/assets/9ef153df-9329-43d3-b023-17a0bb2dbe85)

Light Mode to Dark mode:
![image](https://github.com/user-attachments/assets/e951c298-035d-434f-a153-d590fd25189c)

Dark mode to Light mode:
![image](https://github.com/user-attachments/assets/2b22832c-5e9b-4523-aea6-287ad6e097e6)

