### PR TITLE
Fix Button Sizing and Text Readability in Sponsorship Page Cards

### DIFF
--- a/pages/scholarship-feature/scholarships.css
+++ b/pages/scholarship-feature/scholarships.css
@@ -190,7 +190,7 @@ p {
 
 .card a:hover,
 .card button:hover {
-    background-color: blue;
+    background-color: black;
     color:white;
     transform: translateY(-6px); 
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.6);

--- a/pages/scholarship-feature/scholarships.css
+++ b/pages/scholarship-feature/scholarships.css
@@ -175,7 +175,7 @@ p {
 .card a,
 .card button {
     display: inline-block;
-    padding: 10px 18px;
+    padding: 5px 10px;
     background-color: white; 
     color: black;
     border-radius: 10px;
@@ -190,7 +190,7 @@ p {
 
 .card a:hover,
 .card button:hover {
-    background-color:black;
+    background-color: blue;
     color:white;
     transform: translateY(-6px); 
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.6);
@@ -344,4 +344,26 @@ p {
     margin: 0 15px;
     font-size: 1.1em;
     font-weight: bold;
+}
+.card .buttons{
+    margin-top: 8px;
+    margin-bottom: 10px;
+}
+.read-more{
+    margin-left: 10px;
+}
+.card h4{
+    width: 100%;
+    margin-bottom: 10px;
+}
+.comment-input{
+    height: 1.5rem;
+    margin-right: 10px;
+    border-radius: 10px;
+}
+.card .comments-section{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
 }


### PR DESCRIPTION
### Description:
This PR resolves issue #974 by addressing the button sizing and text readability problems on the Sponsorship page cards. The 'Apply,' 'Read More,' 'Like,' and 'Post' buttons were too large, overlapping and collapsing within the card layout, which disrupted the visual appeal of the page. Additionally, the text contrast for headings and paragraphs was too low, affecting readability.

### Changes Made:
- **Button Resizing:** Adjusted the button sizes to fit within the card layout for a balanced design.
- **Spacing Adjustments:** Added sufficient spacing between buttons to prevent overlap and improve layout organization.
- **Text Contrast Improvement:** Enhanced color contrast for card headings and paragraphs, significantly improving readability and accessibility.
- **Design Consistency:** Maintained a cohesive and visually appealing design throughout the cards.

### Expected Outcome:
With these changes:
- Buttons are now appropriately sized and spaced, enhancing the layout's structure.
- Text inside the cards is easier to read due to improved color contrast.
- Overall, the user experience and visual appeal of the Sponsorship page are improved.

### Screenshot:
![Screenshot 2024-10-26 at 09-09-18 Scholarships](https://github.com/user-attachments/assets/d4f851f8-203d-4b85-95aa-f9e79fb180f7)

**Linked Issue:** Fixes #974