### PR TITLE
Enhanced ScrollTop Button Functionality

### DIFF
--- a/components/ScrollToTop/ScrollToTop.html
+++ b/components/ScrollToTop/ScrollToTop.html
@@ -11,4 +11,15 @@
       <i class="fa-solid fa-arrow-up"></i>
     </a>
   </body>
+  <script>
+      const scrollTopButton = document.querySelector(".scroll-top");
+      scrollTopButton.style.display = "none";
+      window.addEventListener("scroll", function () {
+        if (window.scrollY > 100) {
+          scrollTopButton.style.display = "block";
+        } else {
+          scrollTopButton.style.display = "none";
+        }
+      });
+  </script>
 </html>


### PR DESCRIPTION
## Enhanced ScrollTop Button Functionality

Closes #1162 

- Sets the initial visibility of the scrollTop button to hidden, improving the overall user interface by reducing clutter.
- The button becomes visible only after scrolling down more than 100 pixels, enhancing usability and encouraging seamless navigation back to the top.

@aditya-bhaumik
Pls assign me, give me labels like gssoc-extd and level.